### PR TITLE
ACTUALIZAR TEST VOTING

### DIFF
--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -37,14 +37,22 @@ class VotingTestCase(BaseTestCase):
         for i in range(5):
             opt = QuestionOption(question=q, option='option {}'.format(i+1))
             opt.save()
-        v = Voting(name='test voting', question=q)
+        q2 = Question(desc='test question2')
+        q2.save()
+        for i in range(5):
+            opt2 = QuestionOption(question=q2, option='option2 {}'.format(i+1))
+            opt2.save()
+        lista=[]
+        lista.append(q)
+        lista.append(q2)
+        v = Voting(name='test voting')
         v.save()
+        v.question.set(lista)
 
         a, _ = Auth.objects.get_or_create(url=settings.BASEURL,
                                           defaults={'me': True, 'name': 'test auth'})
         a.save()
         v.auths.add(a)
-
         return v
 
     def create_voters(self, v):


### PR DESCRIPTION
Se ha actualizado el test de voting para que al crear una votación esta tenga 2 preguntas en lugar de una. Problema actual: Los test fallan
ya que para poder votar es necesario realizar antes la integración con la cabina y el postprocesado para dar soporte a las preguntas múltiples
en una misma votación.
El test completo se corregirá cuando se lleve a cabo la integración.