### PR TITLE
ELIMINACION DE HEROKU EN EL SETTINGS.PY

### DIFF
--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -193,6 +193,3 @@ if os.path.exists("config.jsonnet"):
 
 
 INSTALLED_APPS = INSTALLED_APPS + MODULES
-
-import django_heroku
-django_heroku.settings(locals())

--- a/decide/visualizer/templates/visualizer/visualizer.html
+++ b/decide/visualizer/templates/visualizer/visualizer.html
@@ -1,12 +1,10 @@
 {% extends "base.html" %}
-{% load i18n static %}
 
 {% block extrahead %}
     <link type="text/css" rel="stylesheet"
          href="https://unpkg.com/bootstrap/dist/css/bootstrap.min.css" />
     <link type="text/css" rel="stylesheet"
          href="https://unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.css" />
-    <link type="text/css" rel="stylesheet" href="{% static "booth/style.css" %}" />
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Tras el desarrollo del proyecto, se ha decidido que la rama que se desplegará será feature/GitHub-actions-49 por lo que no es necesario tener en master esos archivos.

García Cáceres, María <@margarcac1>